### PR TITLE
REF: Refactor message output handling

### DIFF
--- a/examples/small.md
+++ b/examples/small.md
@@ -38,5 +38,10 @@ import matplotlib.pyplot as plt
 plt.plot(range(4), range(4))
 ```
 
+```{.python}
+print("2 + 2 is")
+2 + 2
+```
+
 Fin.
 

--- a/stitch/stitch_app.py
+++ b/stitch/stitch_app.py
@@ -1,6 +1,8 @@
 '''
 Command line interface, built on traitlets.
 '''
+# Adapted from knitpy and nbcovert:
+
 # Copyright (c) Jan Schulz <jasc@gmx.net>
 # Copyright (c) IPython Development Team.
 # Distributed under the terms of the Modified BSD License.


### PR DESCRIPTION
Pass messages and extract in `wrap_output` instead of tuples of `(output, message)`.